### PR TITLE
try playwright mcp

### DIFF
--- a/web/tests/Yahoo.spec.ts
+++ b/web/tests/Yahoo.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Yahoo Finance Japan", () => {
+  test("Extract 3 main financial news headlines", async ({ page }) => {
+    // Yahoo Finance Japanのトップページにアクセス
+    await page.goto("https://finance.yahoo.co.jp/");
+    
+    // ページタイトルを検証
+    await expect(page).toHaveTitle(/Yahoo!ファイナンス/);
+
+    console.log("Yahoo Finance Japan page loaded successfully");
+
+    // ヘッドラインセクションが表示されるのを待つ
+    const headlineSection = page.locator("text=ヘッドライン").first();
+    await expect(headlineSection).toBeVisible();
+
+    // ニュース記事のリストを取得
+    const newsArticles = page.locator("article a h2").filter({ hasText: /.+/ });
+    
+    // 少なくとも3つのニュース記事があることを確認
+    const count = await newsArticles.count();
+    expect(count).toBeGreaterThanOrEqual(3);
+    console.log(`Found ${count} news articles`);
+
+    // 最初の3つのニュース見出しを抽出
+    const headlines = [];
+    for (let i = 0; i < Math.min(3, count); i++) {
+      const headline = await newsArticles.nth(i).textContent();
+      const timeElement = page.locator("article a").nth(i).locator("time");
+      const time = await timeElement.textContent();
+      
+      const sourceElement = page.locator("article a").nth(i).locator("li").nth(1);
+      const source = await sourceElement.textContent();
+      
+      headlines.push({
+        headline: headline?.trim(),
+        time: time?.trim(),
+        source: source?.trim()
+      });
+      
+      console.log(`Headline ${i+1}: ${headline?.trim()}`);
+    }
+
+    // 少なくとも3つの見出しが取得できたことを確認
+    expect(headlines.length).toBeGreaterThanOrEqual(3);
+    
+    // 各見出しが空でないことを確認
+    headlines.forEach((item, index) => {
+      expect(item.headline).toBeTruthy();
+      console.log(`Headline ${index+1}: ${item.headline} (${item.time} - ${item.source})`);
+    });
+
+    // スクリーンショットを撮る（デバッグ用）
+    await page.screenshot({ path: 'yahoo-finance-japan.png' });
+    
+    console.log("Test completed successfully");
+  });
+});

--- a/web/tests/Yahoo.spec.ts
+++ b/web/tests/Yahoo.spec.ts
@@ -4,7 +4,7 @@ test.describe("Yahoo Finance Japan", () => {
   test("Extract 3 main financial news headlines", async ({ page }) => {
     // Yahoo Finance Japanのトップページにアクセス
     await page.goto("https://finance.yahoo.co.jp/");
-    
+
     // ページタイトルを検証
     await expect(page).toHaveTitle(/Yahoo!ファイナンス/);
 
@@ -16,7 +16,7 @@ test.describe("Yahoo Finance Japan", () => {
 
     // ニュース記事のリストを取得
     const newsArticles = page.locator("article a h2").filter({ hasText: /.+/ });
-    
+
     // 少なくとも3つのニュース記事があることを確認
     const count = await newsArticles.count();
     expect(count).toBeGreaterThanOrEqual(3);
@@ -28,31 +28,39 @@ test.describe("Yahoo Finance Japan", () => {
       const headline = await newsArticles.nth(i).textContent();
       const timeElement = page.locator("article a").nth(i).locator("time");
       const time = await timeElement.textContent();
-      
-      const sourceElement = page.locator("article a").nth(i).locator("li").nth(1);
+
+      const sourceElement = page
+        .locator("article a")
+        .nth(i)
+        .locator("li")
+        .nth(1);
       const source = await sourceElement.textContent();
-      
+
       headlines.push({
         headline: headline?.trim(),
         time: time?.trim(),
-        source: source?.trim()
+        source: source?.trim(),
       });
-      
-      console.log(`Headline ${i+1}: ${headline?.trim()}`);
+
+      console.log(`Headline ${i + 1}: ${headline?.trim()}`);
     }
 
     // 少なくとも3つの見出しが取得できたことを確認
     expect(headlines.length).toBeGreaterThanOrEqual(3);
-    
+
     // 各見出しが空でないことを確認
     headlines.forEach((item, index) => {
       expect(item.headline).toBeTruthy();
-      console.log(`Headline ${index+1}: ${item.headline} (${item.time} - ${item.source})`);
+      console.log(
+        `Headline ${index + 1}: ${item.headline} (${item.time} - ${
+          item.source
+        })`
+      );
     });
 
     // スクリーンショットを撮る（デバッグ用）
-    await page.screenshot({ path: 'yahoo-finance-japan.png' });
-    
+    await page.screenshot({ path: "yahoo-finance-japan.png" });
+
     console.log("Test completed successfully");
   });
 });


### PR DESCRIPTION
参考:
https://qiita.com/t-kurasawa/items/fc47a9133dd6cfe1ae7b

- github copilot (agent mode)との対話の中で、playwrigh mcpを使ったり使わなかったりを明示的に指定できない。頼んでも使わなかったりする。Account.specを消して、自然言語で依頼したけどmcpを使わずに作った。

```
Playwrightを使い、他のフロントエンドのテストやUIコンポーネント等を参考に、/web/tests/Account.spec.tsを実装してください。

以下のテストを実行してください。

ログインする
グローバルメニューからAccount ページに遷移する
最初はAPI Keyが登録されていないことを確認する
API Keyを作成する。APIのモックで指定したキーを画面に表示にすることを確認する
その後API Keyを削除する。表示がNo API Keyになっていることを確認する。
```

- そもそも既存のテストが充実してたら、通常のcopilotで十分実装可能。

- マニュアルテストケースを、スクリプト化するときはいいかも。でも流石にエンジニアのレビューはいるね。

